### PR TITLE
ECL-428: Updated return submitted screen and email for nil returns

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyreturns/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/config/AppConfig.scala
@@ -34,9 +34,10 @@ class AppConfig @Inject() (configuration: Configuration, servicesConfig: Service
   def feedbackUrl(implicit request: RequestHeader): String =
     s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${SafeRedirectUrl(host + request.uri).encodedUrl}"
 
-  val signInUrl: String  = configuration.get[String]("urls.signIn")
-  val signOutUrl: String = configuration.get[String]("urls.signOut")
-  val claimUrl: String   = configuration.get[String]("urls.claim")
+  val signInUrl: String     = configuration.get[String]("urls.signIn")
+  val signOutUrl: String    = configuration.get[String]("urls.signOut")
+  val claimUrl: String      = configuration.get[String]("urls.claim")
+  val eclAccountUrl: String = configuration.get[String]("urls.eclAccount")
 
   private val exitSurveyHost              = configuration.get[String]("feedback-frontend.host")
   private val exitSurveyServiceIdentifier = configuration.get[String]("feedback-frontend.serviceId")

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/connectors/EmailConnector.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyreturns.connectors
 
 import uk.gov.hmrc.economiccrimelevyreturns.config.AppConfig
+import uk.gov.hmrc.economiccrimelevyreturns.models.email.ReturnSubmittedEmailRequest._
 import uk.gov.hmrc.economiccrimelevyreturns.models.email.{ReturnSubmittedEmailParameters, ReturnSubmittedEmailRequest}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
@@ -42,7 +43,9 @@ class EmailConnector @Inject() (appConfig: AppConfig, httpClient: HttpClient)(im
         sendEmailUrl,
         ReturnSubmittedEmailRequest(
           to = Seq(to),
-          parameters = returnSubmittedEmailParameters
+          parameters = returnSubmittedEmailParameters,
+          templateId =
+            if (returnSubmittedEmailParameters.chargeReference.isDefined) ReturnTemplateId else NilReturnTemplateId
         )
       )
       .map {

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/CheckYourAnswersController.scala
@@ -94,7 +94,7 @@ class CheckYourAnswersController @Inject() (
         Seq(SessionKeys.ChargeReference -> c)
       ) ++ Seq(
         SessionKeys.Email             -> request.eclReturn.contactEmailAddress
-          .getOrElse(throw new IllegalStateException("Contact email address not found in session")),
+          .getOrElse(throw new IllegalStateException("Contact email address not found in return data")),
         SessionKeys.ObligationDetails -> Json.toJson(request.eclReturn.obligationDetails).toString(),
         SessionKeys.AmountDue         ->
           request.eclReturn.calculatedLiability

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/CheckYourAnswersController.scala
@@ -23,6 +23,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyreturns.connectors.EclReturnsConnector
 import uk.gov.hmrc.economiccrimelevyreturns.controllers.actions.{AuthorisedAction, DataRetrievalAction, ValidatedReturnAction}
 import uk.gov.hmrc.economiccrimelevyreturns.models.SessionKeys
+import uk.gov.hmrc.economiccrimelevyreturns.models.SessionKeys._
 import uk.gov.hmrc.economiccrimelevyreturns.models.requests.ReturnDataRequest
 import uk.gov.hmrc.economiccrimelevyreturns.services.EmailService
 import uk.gov.hmrc.economiccrimelevyreturns.viewmodels.checkanswers._
@@ -89,22 +90,21 @@ class CheckYourAnswersController @Inject() (
       _         = emailService.sendReturnSubmittedEmail(request.eclReturn, response.chargeReference)
       _        <- eclReturnsConnector.deleteReturn(request.internalId)
     } yield Redirect(routes.ReturnSubmittedController.onPageLoad()).withSession(
-      request.session ++ response.chargeReference.fold(Seq.empty[(String, String)])(c =>
+      request.session.clearEclValues ++ response.chargeReference.fold(Seq.empty[(String, String)])(c =>
         Seq(SessionKeys.ChargeReference -> c)
+      ) ++ Seq(
+        SessionKeys.Email             -> request.eclReturn.contactEmailAddress
+          .getOrElse(throw new IllegalStateException("Contact email address not found in session")),
+        SessionKeys.ObligationDetails -> Json.toJson(request.eclReturn.obligationDetails).toString(),
+        SessionKeys.AmountDue         ->
+          request.eclReturn.calculatedLiability
+            .getOrElse(
+              throw new IllegalStateException("Amount due not found in return data")
+            )
+            .amountDue
+            .amount
+            .toString()
       )
-        ++ Seq(
-          SessionKeys.Email             -> request.eclReturn.contactEmailAddress
-            .getOrElse(throw new IllegalStateException("Contact email address not found in session")),
-          SessionKeys.ObligationDetails -> Json.toJson(request.eclReturn.obligationDetails).toString(),
-          SessionKeys.AmountDue         ->
-            request.eclReturn.calculatedLiability
-              .getOrElse(
-                throw new IllegalStateException("Amount due not found in return data")
-              )
-              .amountDue
-              .amount
-              .toString()
-        )
     )
   }
 

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/CheckYourAnswersController.scala
@@ -89,9 +89,12 @@ class CheckYourAnswersController @Inject() (
       _         = emailService.sendReturnSubmittedEmail(request.eclReturn, response.chargeReference)
       _        <- eclReturnsConnector.deleteReturn(request.internalId)
     } yield Redirect(routes.ReturnSubmittedController.onPageLoad()).withSession(
-      request.session
+      request.session ++ response.chargeReference.fold(Seq.empty[(String, String)])(c =>
+        Seq(SessionKeys.ChargeReference -> c)
+      )
         ++ Seq(
-          SessionKeys.ChargeReference   -> response.chargeReference,
+          SessionKeys.Email             -> request.eclReturn.contactEmailAddress
+            .getOrElse(throw new IllegalStateException("Contact email address not found in session")),
           SessionKeys.ObligationDetails -> Json.toJson(request.eclReturn.obligationDetails).toString(),
           SessionKeys.AmountDue         ->
             request.eclReturn.calculatedLiability

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/SessionKeys.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/SessionKeys.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.economiccrimelevyreturns.models
 
+import play.api.mvc.Session
+
 object SessionKeys {
 
   val ChargeReference: String   = "chargeReference"
@@ -23,4 +25,7 @@ object SessionKeys {
   val AmountDue: String         = "amountDue"
   val ObligationDetails: String = "obligationDetails"
 
+  implicit class SessionOps(s: Session) {
+    def clearEclValues: Session = s -- Seq(ChargeReference, Email, AmountDue, ObligationDetails)
+  }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/SessionKeys.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/SessionKeys.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.economiccrimelevyreturns.models
 object SessionKeys {
 
   val ChargeReference: String   = "chargeReference"
+  val Email: String             = "email"
   val AmountDue: String         = "amountDue"
   val ObligationDetails: String = "obligationDetails"
 

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/SubmitEclReturnResponse.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/SubmitEclReturnResponse.scala
@@ -22,7 +22,7 @@ import java.time.Instant
 
 final case class SubmitEclReturnResponse(
   processingDate: Instant,
-  chargeReference: String
+  chargeReference: Option[String]
 )
 
 object SubmitEclReturnResponse {

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/email/ReturnSubmittedEmailRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/email/ReturnSubmittedEmailRequest.scala
@@ -23,10 +23,10 @@ final case class ReturnSubmittedEmailParameters(
   dateSubmitted: String,
   periodStartDate: String,
   periodEndDate: String,
-  chargeReference: String,
+  chargeReference: Option[String],
   fyStartYear: String,
   fyEndYear: String,
-  datePaymentDue: String,
+  datePaymentDue: Option[String],
   amountDue: String
 )
 
@@ -36,13 +36,14 @@ object ReturnSubmittedEmailParameters {
 
 final case class ReturnSubmittedEmailRequest(
   to: Seq[String],
-  templateId: String = ReturnSubmittedEmailRequest.TemplateId,
+  templateId: String,
   parameters: ReturnSubmittedEmailParameters,
   force: Boolean = false,
   eventUrl: Option[String] = None
 )
 
 object ReturnSubmittedEmailRequest {
-  val TemplateId: String                                    = "ecl_return_submitted"
+  val ReturnTemplateId: String                              = "ecl_return_submitted"
+  val NilReturnTemplateId: String                           = "ecl_nil_return_submitted"
   implicit val format: OFormat[ReturnSubmittedEmailRequest] = Json.format[ReturnSubmittedEmailRequest]
 }

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/services/EmailService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/services/EmailService.scala
@@ -29,7 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class EmailService @Inject() (emailConnector: EmailConnector)(implicit ec: ExecutionContext) extends Logging {
 
-  def sendReturnSubmittedEmail(eclReturn: EclReturn, chargeReference: String)(implicit
+  def sendReturnSubmittedEmail(eclReturn: EclReturn, chargeReference: Option[String])(implicit
     hc: HeaderCarrier,
     messages: Messages
   ): Future[Unit] = {
@@ -63,7 +63,7 @@ class EmailService @Inject() (emailConnector: EmailConnector)(implicit ec: Execu
             chargeReference = chargeReference,
             fyStartYear = fyStartYear,
             fyEndYear = fyEndYear,
-            datePaymentDue = eclDueDate,
+            datePaymentDue = if (chargeReference.isDefined) Some(eclDueDate) else None,
             amountDue = amountDue
           )
         )

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/views/NilReturnSubmittedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/views/NilReturnSubmittedView.scala.html
@@ -24,31 +24,29 @@
         appConfig: AppConfig
 )
 
-@(chargeReference: String, submittedWhen: String, dueDate: String, fyStartYear: String, fyEndYear: String, amountToPay: BigDecimal, email: String)(implicit request: Request[_], messages: Messages)
+@(submittedWhen: String, fyStartYear: String, fyEndYear: String, amountToPay: BigDecimal, email: String)(implicit request: Request[_], messages: Messages)
 
 @panelContentHtml = {
-    <p class="govuk-label--m">@messages("submitted.reference", chargeReference)</p>
-    <p class="govuk-label--m">@messages("submitted.amountToPay", ViewUtils.formatMoney(amountToPay))</p>
+    <p class="govuk-label--m">@messages("nilSubmitted.amountToPay", ViewUtils.formatMoney(amountToPay))</p>
 }
 
 @layout(
-    pageTitle = title(messages("submitted.title")),
+    pageTitle = title(messages("nilSubmitted.title")),
     showBackLink = false
 ) {
 
     @govukPanel(Panel(
-        title = HtmlContent(messages("submitted.heading")),
+        title = HtmlContent(messages("nilSubmitted.heading")),
         content = HtmlContent(panelContentHtml)
     ))
 
-    <h2 class="govuk-heading-m">@messages("submitted.subHeading")</h2>
+    <h2 class="govuk-heading-m">@messages("nilSubmitted.subHeading")</h2>
 
-    <p class="govuk-body">@messages("submitted.p1", submittedWhen, fyStartYear, fyEndYear)</p>
-    <p class="govuk-body">@messages("submitted.p2", dueDate)</p>
-    <p class="govuk-body">@Html(messages("submitted.p3", appConfig.eclAccountUrl))</p>
-    <p class="govuk-body">@messages("submitted.p4")</p>
-    <p class="govuk-body">@Html(messages("submitted.p5"))</p>
-    <p class="govuk-body">@messages("submitted.p6", email)</p>
+    <p class="govuk-body">@messages("nilSubmitted.p1", submittedWhen, fyStartYear, fyEndYear)</p>
+
+    <p class="govuk-body">@Html(messages("nilSubmitted.p2", appConfig.eclAccountUrl))</p>
+
+    <p class="govuk-body">@messages("nilSubmitted.p3", email)</p>
 
     <p class="govuk-body">@Html(messages("exit.survey", messages("exit.survey.link", appConfig.exitSurveyUrl)))</p>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -120,6 +120,7 @@ urls {
   signIn = "http://localhost:9949/auth-login-stub/gg-sign-in"
   signOut = "http://localhost:9025/gg/sign-out"
   claim = "http://localhost:14007/add-economic-crime-levy/do-you-have-an-ecl-reference-number"
+  eclAccount = "http://localhost:14008/economic-crime-levy-account"
 }
 
 host = "http://localhost:14002"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -194,12 +194,20 @@ submitted.heading = Return submitted
 submitted.reference = ECL return number: {0}
 submitted.amountToPay = Amount you need to pay: {0}
 submitted.subHeading = What you need to do next
-submitted.p1 = You have submitted a return for the Economic Crime Levy (ECL) on {0} for the financial year {1}/{2}.
-submitted.p2 = You will receive a confirmation email. Please save this for your records.
-submitted.p3 = You must pay the levy for the {0}/{1} financial year by {2}. Your ECL return number must be used as a payment reference when you pay the levy.
+submitted.p1 = You have submitted a return for the Economic Crime Levy (ECL) on {0} for the financial year {1}/{2}. You will receive a confirmation email. Please save this for your records.
+submitted.p2 = You must pay the levy by {0}.
+submitted.p3 = Your ECL return number must be used as a payment reference when you pay the levy. You will also be able to find your return number in your <a href="{0}" class="govuk-link">ECL account</a>.
 submitted.p4 = You will be charged interest if you make a late payment.
-submitted.payNow = You can {0} if you are ready.
-submitted.payNow.link = <a href="{0}" class="govuk-link">pay now</a>
+submitted.p5 = You can pay the levy by reading the <a href="https://www.gov.uk/guidance/pay-the-economic-crime-levy" class="govuk-link">guidance on how to pay</a>.
+submitted.p6 = We have sent a confirmation email to {0}. Please save this for your records.
+
+nilSubmitted.title = Return submitted
+nilSubmitted.heading = Return submitted
+nilSubmitted.amountToPay = Amount you need to pay: {0}
+nilSubmitted.subHeading = What you need to do next
+nilSubmitted.p1 = You have submitted a return for the Economic Crime Levy (ECL) on {0} for the financial year {1}/{2}. You do not need to pay the levy for this financial year.
+nilSubmitted.p2 = You can find information about your return in your <a href="{0}" class="govuk-link">ECL account</a>
+nilSubmitted.p3 = We have sent a confirmation email to {0}. Please save this for your records.
 
 exit.survey.link = <a href="{0}" class="govuk-link">What did you think of this service?</a>
 exit.survey = {0} (takes 30 seconds) to exit survey.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -199,14 +199,14 @@ submitted.p2 = You must pay the levy by {0}.
 submitted.p3 = Your ECL return number must be used as a payment reference when you pay the levy. You will also be able to find your return number in your <a href="{0}" class="govuk-link">ECL account</a>.
 submitted.p4 = You will be charged interest if you make a late payment.
 submitted.p5 = You can pay the levy by reading the <a href="https://www.gov.uk/guidance/pay-the-economic-crime-levy" class="govuk-link">guidance on how to pay</a>.
-submitted.p6 = We have sent a confirmation email to {0}. Please save this for your records.
+submitted.p6 = We have sent a confirmation email to {0}
 
 nilSubmitted.title = Return submitted
 nilSubmitted.heading = Return submitted
 nilSubmitted.amountToPay = Amount you need to pay: {0}
 nilSubmitted.subHeading = What you need to do next
 nilSubmitted.p1 = You have submitted a return for the Economic Crime Levy (ECL) on {0} for the financial year {1}/{2}. You do not need to pay the levy for this financial year.
-nilSubmitted.p2 = You can find information about your return in your <a href="{0}" class="govuk-link">ECL account</a>
+nilSubmitted.p2 = You can find information about your return in your <a href="{0}" class="govuk-link">ECL account</a>.
 nilSubmitted.p3 = We have sent a confirmation email to {0}. Please save this for your records.
 
 exit.survey.link = <a href="{0}" class="govuk-link">What did you think of this service?</a>

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/CheckYourAnswersISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/CheckYourAnswersISpec.scala
@@ -58,7 +58,7 @@ class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
       stubAuthorised()
 
       val validEclReturn      = random[ValidEclReturn]
-      val chargeReference     = random[String]
+      val chargeReference     = random[Option[String]]
       val obligationDetails   = validEclReturn.eclReturn.obligationDetails.get
       val calculatedLiability = validEclReturn.eclReturn.calculatedLiability.get
 
@@ -91,14 +91,16 @@ class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
         chargeReference = chargeReference,
         fyStartYear = obligationDetails.inboundCorrespondenceFromDate.getYear.toString,
         fyEndYear = obligationDetails.inboundCorrespondenceToDate.getYear.toString,
-        datePaymentDue = eclDueDate,
+        datePaymentDue = if (chargeReference.isDefined) Some(eclDueDate) else None,
         amountDue = amountDue
       )
 
       stubSendReturnSubmittedEmail(
         ReturnSubmittedEmailRequest(
           to = Seq(validEclReturn.eclReturn.contactEmailAddress.get),
-          parameters = emailParams
+          parameters = emailParams,
+          templateId = if (chargeReference.isDefined) { ReturnSubmittedEmailRequest.ReturnTemplateId }
+          else { ReturnSubmittedEmailRequest.NilReturnTemplateId }
         )
       )
 

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/ReturnSubmittedISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/ReturnSubmittedISpec.scala
@@ -30,23 +30,48 @@ class ReturnSubmittedISpec extends ISpecBase with AuthorisedBehaviour {
   s"GET ${routes.ReturnSubmittedController.onPageLoad().url}" should {
     behave like authorisedActionRoute(routes.ReturnSubmittedController.onPageLoad())
 
-    "respond with 200 status and the return submitted HTML view" in {
+    "respond with 200 status and the return submitted HTML view when it is not a nil return" in {
       stubAuthorised()
 
       val chargeReference   = random[String]
+      val email             = random[String]
       val obligationDetails = random[ObligationDetails]
-      val amountDue = "10000"
+      val amountDue         = "10000"
 
       val result = callRoute(
         FakeRequest(routes.ReturnSubmittedController.onPageLoad())
           .withSession(
             (SessionKeys.ChargeReference, chargeReference),
+            (SessionKeys.Email, email),
             (SessionKeys.ObligationDetails, Json.toJson(obligationDetails).toString()),
-              (SessionKeys.AmountDue, amountDue))
+            (SessionKeys.AmountDue, amountDue)
+          )
       )
 
       status(result) shouldBe OK
       html(result)     should include("Return submitted")
+      html(result)     should include("ECL return number")
+    }
+
+    "respond with 200 status and the nil return submitted HTML view when it is a nil return" in {
+      stubAuthorised()
+
+      val email             = random[String]
+      val obligationDetails = random[ObligationDetails]
+      val amountDue         = "10000"
+
+      val result = callRoute(
+        FakeRequest(routes.ReturnSubmittedController.onPageLoad())
+          .withSession(
+            (SessionKeys.Email, email),
+            (SessionKeys.ObligationDetails, Json.toJson(obligationDetails).toString()),
+            (SessionKeys.AmountDue, amountDue)
+          )
+      )
+
+      status(result) shouldBe OK
+      html(result)     should include("Return submitted")
+      html(result)     should not include "ECL return number"
     }
   }
 

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/base/EclReturnsStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/base/EclReturnsStubs.scala
@@ -52,7 +52,7 @@ trait EclReturnsStubs { self: WireMockStubs =>
       }
     )
 
-  def stubSubmitReturn(chargeReference: String): StubMapping =
+  def stubSubmitReturn(chargeReference: Option[String]): StubMapping =
     stub(
       post(urlEqualTo(s"/economic-crime-levy-returns/submit-return/$testInternalId")),
       aResponse()

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/services/EmailServiceSpec.scala
@@ -35,7 +35,7 @@ class EmailServiceSpec extends SpecBase {
 
   "sendReturnSubmittedEmail" should {
     "send an email to the contact in the return" in forAll {
-      (validEclReturn: ValidEclReturn, chargeReference: String) =>
+      (validEclReturn: ValidEclReturn, chargeReference: Option[String]) =>
         val obligationDetails   = validEclReturn.eclReturn.obligationDetails.get
         val calculatedLiability = validEclReturn.eclReturn.calculatedLiability.get
 
@@ -56,7 +56,7 @@ class EmailServiceSpec extends SpecBase {
           chargeReference = chargeReference,
           fyStartYear = obligationDetails.inboundCorrespondenceFromDate.getYear.toString,
           fyEndYear = obligationDetails.inboundCorrespondenceToDate.getYear.toString,
-          datePaymentDue = eclDueDate,
+          datePaymentDue = if (chargeReference.isDefined) Some(eclDueDate) else None,
           amountDue
         )
 
@@ -81,7 +81,7 @@ class EmailServiceSpec extends SpecBase {
     }
 
     "throw an IllegalStateException when there are no obligation details in the return data" in forAll {
-      (internalId: String, chargeReference: String) =>
+      (internalId: String, chargeReference: Option[String]) =>
         val result = intercept[IllegalStateException] {
           await(service.sendReturnSubmittedEmail(EclReturn.empty(internalId), chargeReference)(hc, messages))
         }
@@ -92,7 +92,7 @@ class EmailServiceSpec extends SpecBase {
     "throw an IllegalStateException when the contact details are missing" in forAll {
       (
         internalId: String,
-        chargeReference: String,
+        chargeReference: Option[String],
         obligationDetails: ObligationDetails,
         calculatedLiability: CalculatedLiability
       ) =>


### PR DESCRIPTION
Also brings the normal return submitted screen up to the latest version in the confluence. This does part of the work required for ECL-407.