### PR TITLE
DDCYLS-5290 Change to caclulation request model data

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyreturns/connectors/EclCalculatorConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/connectors/EclCalculatorConnector.scala
@@ -39,13 +39,19 @@ class EclCalculatorConnector @Inject() (
 
   private val eclCalculatorUrl: String = s"${appConfig.eclCalculatorBaseUrl}/economic-crime-levy-calculator"
 
-  def calculateLiability(amlRegulatedActivityLength: Int, relevantApLength: Int, relevantApRevenue: BigDecimal)(implicit
+  def calculateLiability(
+    amlRegulatedActivityLength: Int,
+    relevantApLength: Int,
+    relevantApRevenue: BigDecimal,
+    taxYearStart: Int
+  )(implicit
     hc: HeaderCarrier
   ): Future[CalculatedLiability] = {
     val body = CalculateLiabilityRequest(
       amlRegulatedActivityLength = amlRegulatedActivityLength,
       relevantApLength = relevantApLength,
-      ukRevenue = relevantApRevenue.toLong
+      ukRevenue = relevantApRevenue.toLong,
+      year = taxYearStart
     )
 
     retryFor[CalculatedLiability]("ECL Calculator Connector - calculate liability")(retryCondition) {

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/connectors/ReturnsConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/connectors/ReturnsConnector.scala
@@ -50,21 +50,6 @@ class ReturnsConnector @Inject() (
   def deleteReturn(internalId: String)(implicit hc: HeaderCarrier): Future[Unit] =
     httpClient.delete(url"$eclReturnsUrl/returns/$internalId").executeAndExpect(NO_CONTENT)
 
-  def calculateLiability(amlRegulatedActivityLength: Int, relevantApLength: Int, relevantApRevenue: Long)(implicit
-    hc: HeaderCarrier
-  ): Future[CalculatedLiability] = {
-    val calculatedLiabilityRequest = CalculateLiabilityRequest(
-      amlRegulatedActivityLength = amlRegulatedActivityLength,
-      relevantApLength = relevantApLength,
-      ukRevenue = relevantApRevenue
-    )
-
-    httpClient
-      .post(url"$eclReturnsUrl/calculate-liability")
-      .withBody(Json.toJson(calculatedLiabilityRequest))
-      .executeAndDeserialise[CalculatedLiability]
-  }
-
   def validateEclReturn(
     internalId: String
   )(implicit hc: HeaderCarrier): OptionT[Future, String] =

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/CalculateLiabilityRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/CalculateLiabilityRequest.scala
@@ -18,7 +18,12 @@ package uk.gov.hmrc.economiccrimelevyreturns.models
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class CalculateLiabilityRequest(amlRegulatedActivityLength: Int, relevantApLength: Int, ukRevenue: Long)
+final case class CalculateLiabilityRequest(
+  amlRegulatedActivityLength: Int,
+  relevantApLength: Int,
+  ukRevenue: Long,
+  year: Int
+)
 
 object CalculateLiabilityRequest {
   implicit val format: OFormat[CalculateLiabilityRequest] = Json.format[CalculateLiabilityRequest]

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/AmlRegulatedActivityLengthISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/AmlRegulatedActivityLengthISpec.scala
@@ -18,7 +18,12 @@ class AmlRegulatedActivityLengthISpec extends ISpecBase with AuthorisedBehaviour
     val updatedReturn       = eclReturn.copy(amlRegulatedActivityLength = Some(length))
     val calculatedLiability = random[CalculatedLiability]
     stubCalculateLiability(
-      CalculateLiabilityRequest(length, fullYear, ukRevenue.longValue),
+      CalculateLiabilityRequest(
+        length,
+        fullYear,
+        ukRevenue.longValue,
+        eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear
+      ),
       calculatedLiability
     )
     updatedReturn.copy(calculatedLiability = Some(calculatedLiability))

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/UkRevenueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/UkRevenueISpec.scala
@@ -76,7 +76,15 @@ class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
       )
 
       stubUpsertReturn(updatedReturn)
-      stubCalculateLiability(CalculateLiabilityRequest(fullYear, fullYear, ukRevenue.toLong), calculatedLiability)
+      stubCalculateLiability(
+        CalculateLiabilityRequest(
+          fullYear,
+          fullYear,
+          ukRevenue.toLong,
+          eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear
+        ),
+        calculatedLiability
+      )
       stubUpsertReturn(updatedReturn.copy(calculatedLiability = Some(calculatedLiability)))
 
       val result = callRoute(
@@ -114,7 +122,12 @@ class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
 
       stubUpsertReturn(updatedReturn)
       stubCalculateLiability(
-        CalculateLiabilityRequest(fullYear, fullYear, ukRevenue.toLong),
+        CalculateLiabilityRequest(
+          fullYear,
+          fullYear,
+          ukRevenue.toLong,
+          eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear
+        ),
         calculatedLiability
       )
       stubUpsertReturn(updatedReturn.copy(calculatedLiability = Some(calculatedLiability)))

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/connectors/EclCalculatorConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/connectors/EclCalculatorConnectorSpec.scala
@@ -49,7 +49,8 @@ class EclCalculatorConnectorSpec extends SpecBase {
           connector.calculateLiability(
             calculateLiabilityRequest.amlRegulatedActivityLength,
             calculateLiabilityRequest.relevantApLength,
-            calculateLiabilityRequest.ukRevenue
+            calculateLiabilityRequest.ukRevenue,
+            calculateLiabilityRequest.year
           )
         )
 
@@ -69,7 +70,7 @@ class EclCalculatorConnectorSpec extends SpecBase {
         when(mockRequestBuilder.execute[HttpResponse](any(), any()))
           .thenReturn(Future.successful(HttpResponse.apply(errorCode, "Internal server error")))
 
-        Try(await(connector.calculateLiability(any(), any(), any()))) match {
+        Try(await(connector.calculateLiability(any(), any(), any(), any()))) match {
           case Failure(UpstreamErrorResponse(_, code, _, _)) =>
             code shouldEqual errorCode
           case _                                             => fail("expected UpstreamErrorResponse when an error is received from the account service")

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/connectors/ReturnsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/connectors/ReturnsConnectorSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.economiccrimelevyreturns.connectors
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
@@ -24,7 +23,7 @@ import play.api.libs.json.{JsNull, Json}
 import uk.gov.hmrc.economiccrimelevyreturns.ValidGetEclReturnSubmissionResponse
 import uk.gov.hmrc.economiccrimelevyreturns.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyreturns.generators.CachedArbitraries._
-import uk.gov.hmrc.economiccrimelevyreturns.models.{CalculatedLiability, EclReturn, SubmitEclReturnResponse}
+import uk.gov.hmrc.economiccrimelevyreturns.models.{EclReturn, SubmitEclReturnResponse}
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HttpResponse, StringContextOps, UpstreamErrorResponse}
 
@@ -269,25 +268,6 @@ class ReturnsConnectorSpec extends SpecBase {
           code shouldEqual errorCode
         case _                                             => fail("expected UpstreamErrorResponse when an error is received from the returns service")
       }
-    }
-
-    "return calculated liability" in {
-      beforeEach()
-
-      val expectedUrl         = url"$eclReturnsUrl/calculate-liability"
-      val calculatedLiability = random[CalculatedLiability]
-
-      when(mockHttpClient.post(ArgumentMatchers.eq(expectedUrl))(any()))
-        .thenReturn(mockRequestBuilder)
-      when(mockRequestBuilder.withBody(any())(any(), any(), any()))
-        .thenReturn(mockRequestBuilder)
-      when(mockRequestBuilder.execute[HttpResponse](any(), any()))
-        .thenReturn(Future.successful(HttpResponse.apply(OK, Json.stringify(Json.toJson(calculatedLiability)))))
-
-      val result = await(connector.calculateLiability(random[Int], random[Int], random[Long]))
-
-      result shouldBe calculatedLiability
-
     }
   }
 }

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/controllers/StartAmendControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/controllers/StartAmendControllerSpec.scala
@@ -111,7 +111,7 @@ class StartAmendControllerSpec extends SpecBase {
         when(mockSessionService.upsert(any())(any()))
           .thenReturn(EitherT.right(unit))
 
-        when(mockEclLiabilityService.getCalculatedLiability(any(), any(), any())(any()))
+        when(mockEclLiabilityService.getCalculatedLiability(any(), any(), any(), any())(any()))
           .thenReturn(
             EitherT[Future, LiabilityCalculationError, CalculatedLiability](
               Future.successful(Right(calculatedLiability))
@@ -268,7 +268,7 @@ class StartAmendControllerSpec extends SpecBase {
             )
           )
 
-        when(mockEclLiabilityService.getCalculatedLiability(any(), any(), any())(any()))
+        when(mockEclLiabilityService.getCalculatedLiability(any(), any(), any(), any())(any()))
           .thenReturn(
             EitherT[Future, LiabilityCalculationError, CalculatedLiability](
               Future.successful(Left(LiabilityCalculationError.InternalUnexpectedError(None, None)))
@@ -324,7 +324,7 @@ class StartAmendControllerSpec extends SpecBase {
             )
           )
 
-        when(mockEclLiabilityService.getCalculatedLiability(any(), any(), any())(any()))
+        when(mockEclLiabilityService.getCalculatedLiability(any(), any(), any(), any())(any()))
           .thenReturn(
             EitherT[Future, LiabilityCalculationError, CalculatedLiability](
               Future.successful(Right(calculatedLiability))

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/models/CalculateLiabilityRequestModelSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/models/CalculateLiabilityRequestModelSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyreturns.models
+
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.economiccrimelevyreturns.base.SpecBase
+
+class CalculateLiabilityRequestModelSpec extends SpecBase {
+
+  val json: JsObject = Json.obj(
+    "amlRegulatedActivityLength" -> 1,
+    "relevantApLength"           -> 2,
+    "ukRevenue"                  -> 200,
+    "year"                       -> 2000
+  )
+
+  val model: CalculateLiabilityRequest = CalculateLiabilityRequest(1, 2, 200, 2000)
+
+  "CalculateLiabilityRequestModel" should {
+
+    "read from JSON" in {
+      json.as[CalculateLiabilityRequest] shouldBe model
+    }
+
+    "write to JSON" in {
+      Json.toJson(model) shouldBe json
+    }
+  }
+}

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/models/EclReturnSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/models/EclReturnSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyreturns.models
 
 import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
-import play.api.libs.json.{JsBoolean, JsError, JsResultException, JsString, Json}
+import play.api.libs.json._
 import uk.gov.hmrc.economiccrimelevyreturns.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyreturns.generators.CachedArbitraries._
 

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/services/EclLiabilityServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/services/EclLiabilityServiceSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.economiccrimelevyreturns.services
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Gen
+import play.api.http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.economiccrimelevyreturns.ValidEclReturn
 import uk.gov.hmrc.economiccrimelevyreturns.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyreturns.connectors.EclCalculatorConnector
@@ -26,7 +27,6 @@ import uk.gov.hmrc.economiccrimelevyreturns.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyreturns.models.errors.LiabilityCalculationError
 import uk.gov.hmrc.economiccrimelevyreturns.models.{CalculatedLiability, EclReturn}
 import uk.gov.hmrc.http.UpstreamErrorResponse
-import play.api.http.Status.INTERNAL_SERVER_ERROR
 
 import scala.concurrent.Future
 
@@ -41,7 +41,8 @@ class EclLiabilityServiceSpec extends SpecBase {
           mockEclCalculatorConnector.calculateLiability(
             ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength),
             ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApLength),
-            ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue)
+            ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue),
+            ArgumentMatchers.eq(validEclReturn.eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear)
           )(any())
         ).thenReturn(Future.successful(calculatedLiability))
 
@@ -80,7 +81,8 @@ class EclLiabilityServiceSpec extends SpecBase {
         mockEclCalculatorConnector.calculateLiability(
           ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength),
           ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApLength),
-          ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue)
+          ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue),
+          ArgumentMatchers.eq(validEclReturn.eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear)
         )(any())
       ).thenReturn(Future.failed(UpstreamErrorResponse("Internal server error", errorCode)))
 
@@ -119,7 +121,8 @@ class EclLiabilityServiceSpec extends SpecBase {
           mockEclCalculatorConnector.calculateLiability(
             ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength),
             ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApLength),
-            ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue)
+            ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue),
+            ArgumentMatchers.eq(validEclReturn.eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear)
           )(any())
         ).thenReturn(Future.successful(calculatedLiability))
 
@@ -128,7 +131,8 @@ class EclLiabilityServiceSpec extends SpecBase {
             .getCalculatedLiability(
               validEclReturn.eclLiabilityCalculationData.relevantApLength,
               validEclReturn.eclLiabilityCalculationData.relevantApRevenue,
-              validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength
+              validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength,
+              validEclReturn.eclReturn.obligationDetails.get
             )
             .value
         )
@@ -144,7 +148,8 @@ class EclLiabilityServiceSpec extends SpecBase {
           mockEclCalculatorConnector.calculateLiability(
             ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength),
             ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApLength),
-            ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue)
+            ArgumentMatchers.eq(validEclReturn.eclLiabilityCalculationData.relevantApRevenue),
+            ArgumentMatchers.eq(validEclReturn.eclReturn.obligationDetails.get.inboundCorrespondenceFromDate.getYear)
           )(any())
         ).thenReturn(Future.failed(UpstreamErrorResponse("Internal server error", errorCode)))
       )
@@ -154,7 +159,8 @@ class EclLiabilityServiceSpec extends SpecBase {
           .getCalculatedLiability(
             validEclReturn.eclLiabilityCalculationData.relevantApLength,
             validEclReturn.eclLiabilityCalculationData.relevantApRevenue,
-            validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength
+            validEclReturn.eclLiabilityCalculationData.amlRegulatedActivityLength,
+            validEclReturn.eclReturn.obligationDetails.get
           )
           .value
       )


### PR DESCRIPTION
The start year for the calculation is retrieved from the obligation "from" date

A function was removed: `ReturnsConnector.calculateLiability`, this was unused and the returns service does not have the associated route it would have called anyway. It seems to me like it was a previous implementation of the calc before the calc microservice was created.